### PR TITLE
Door cache reworking (also adds Comedy Club)

### DIFF
--- a/resources/orp/client/systems/doors.mjs
+++ b/resources/orp/client/systems/doors.mjs
@@ -49,6 +49,7 @@ export function syncDoors() {
 
 // Dynamic Door Functionality
 alt.onServer('door:RenderDoors', doors => {
+    alt.log(`Rendering doors; ${doors}`);
     if (dynamicDoors.length >= 1) {
         dynamicDoors.forEach(door => {
             native.deleteEntity(door.enter);
@@ -57,21 +58,20 @@ alt.onServer('door:RenderDoors', doors => {
 
     if (doors.length <= 0) return;
     doors.forEach(door => {
-        const enterData = JSON.parse(door.enter);
-        const enterHash = native.getHashKey(enterData.doorModel);
+        const enterHash = native.getHashKey(door.enter.doorModel);
 
         alt.loadModel(enterHash);
         native.requestModel(enterHash);
         const enter = native.createObject(
             enterHash,
-            enterData.doorPos.x,
-            enterData.doorPos.y,
-            enterData.doorPos.z,
+            door.enter.doorPos.x,
+            door.enter.doorPos.y,
+            door.enter.doorPos.z,
             false,
             false,
             false
         );
-        native.setEntityHeading(enter, enterData.doorRot);
+        native.setEntityHeading(enter, door.enter.doorRot);
         native.setEntityAlpha(enter, 0, false);
 
         dynamicDoors.push({
@@ -138,10 +138,8 @@ alt.on('meta:Changed', (key, data) => {
         native.requestIpl(data.interior);
     }
 
-    const exitData = JSON.parse(data.exit);
-
     interval = alt.setInterval(() => {
-        const dist = distance(alt.Player.local.pos, exitData.position);
+        const dist = distance(alt.Player.local.pos, data.exit.position);
         if (dist >= 3) return;
         native.beginTextCommandDisplayHelp('STRING');
         native.addTextComponentSubstringPlayerName(

--- a/resources/orp/client/systems/doors.mjs
+++ b/resources/orp/client/systems/doors.mjs
@@ -163,7 +163,7 @@ alt.onServer('editingDoor', state => {
         native.deleteEntity(editDoorId);
 
         const doorData = {
-            guid: -1,
+            id: 0,
             enter: {
                 position: alt.Player.local.pos,
                 doorPos: doorPosition,
@@ -178,9 +178,7 @@ alt.onServer('editingDoor', state => {
                 }
             },
             interior: '',
-            lockstate: 0,
             isGarage: 0,
-            salePrice: -1
         };
 
         alt.log(JSON.stringify(doorData, null, '\t'));

--- a/resources/orp/server/commands/sandbox.mjs
+++ b/resources/orp/server/commands/sandbox.mjs
@@ -264,6 +264,11 @@ chat.registerCmd('tempdoor', (player, args) => {
     }
 });
 
+chat.registerCmd('fixdim', player => {
+    player.dimension = 0;
+    player.saveDimension(0);
+});
+
 chat.registerCmd('creategang', (player, args) => {
     const name = args[0];
     if (!name) return;

--- a/resources/orp/server/configuration/doors.mjs
+++ b/resources/orp/server/configuration/doors.mjs
@@ -444,5 +444,65 @@ export const Doors = [
         lockstate: 0,
         isGarage: 0,
         salePrice: 85000
+    },
+    {
+        // Strip Club
+        id: 16,
+        guid: -1,
+        enter: {
+            position: {
+                x: -379.4474792480469,
+                y: 219.0102996826172,
+                z: 83.65795135498047
+            },
+            doorPos: {
+                x: -380.0100402832031,
+                y: 217.66558837890625,
+                z: 83.96115112304688
+            },
+            doorRot: 0,
+            doorModel: 'prop_cntrdoor_ld_l'
+        },
+        exit: {
+            position: {
+                x: 127.9552,
+                y: -1298.503,
+                z: 29.41962
+            }
+        },
+        interior: '',
+        lockstate: 0,
+        isGarage: 0,
+        salePrice: -1
+    },
+    {
+        // Strip Club (DJ Booth)
+        id: 17,
+        guid: -1,
+        enter: {
+		position: {
+			x: -394.3876037597656,
+			y: 209.46859741210938,
+			z: 83.61905670166016
+		},
+		doorPos: {
+			x: -393.7504577636719,
+			y: 209.10105895996094,
+			z: 83.98570251464844
+		},
+		doorRot: -90,
+		doorModel: 'prop_cntrdoor_ld_l'
+        },
+        exit: {
+            position: {
+                x: 126.135,
+                y: -1278.583,
+                z: 29.270
+            }
+        },
+        interior: '',
+        lockstate: 0,
+        isGarage: 0,
+        salePrice: -1
     }
 ];

--- a/resources/orp/server/configuration/doors.mjs
+++ b/resources/orp/server/configuration/doors.mjs
@@ -1,5 +1,6 @@
-// These doors are only established; when you first run the server.
-// The doors must be added manually after you run the server.
+// Dynamic door configuration
+// Dynamic values such as guid, lockstate, sector comes from DB.
+// Those values defined here will be the defaults when the DB is populated.
 // GUID of -1 means that there is NO OWNER.
 // Normal Doors Use -> prop_cntrdoor_ld_l
 
@@ -10,6 +11,7 @@
 
 export const Doors = [
     {
+        id: 1,
         guid: -1,
         enter: {
             position: {
@@ -38,6 +40,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 2,
         guid: -1,
         enter: {
             position: {
@@ -66,6 +69,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 3,
         guid: -1,
         enter: {
             position: {
@@ -94,6 +98,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 4,
         guid: -1,
         enter: {
             position: {
@@ -122,6 +127,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 5,
         guid: -1,
         enter: {
             position: {
@@ -150,6 +156,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 6,
         guid: -1,
         enter: {
             position: {
@@ -178,6 +185,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 7,
         guid: -1,
         enter: {
             position: {
@@ -206,6 +214,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 8,
         guid: -1,
         enter: {
             position: {
@@ -234,6 +243,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 9,
         guid: -1,
         enter: {
             position: {
@@ -262,6 +272,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 10,
         guid: -1,
         enter: {
             position: {
@@ -290,6 +301,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 11,
         guid: -1,
         enter: {
             position: {
@@ -318,6 +330,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 12,
         guid: -1,
         enter: {
             position: {
@@ -346,6 +359,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 13,
         guid: -1,
         enter: {
             position: {
@@ -374,6 +388,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 14,
         guid: -1,
         enter: {
             position: {
@@ -402,6 +417,7 @@ export const Doors = [
         salePrice: 85000
     },
     {
+        id: 15,
         guid: -1,
         enter: {
             position: {

--- a/resources/orp/server/configuration/doors.mjs
+++ b/resources/orp/server/configuration/doors.mjs
@@ -446,63 +446,33 @@ export const Doors = [
         salePrice: 85000
     },
     {
-        // Strip Club
+        // Comedy Club
         id: 16,
         guid: -1,
         enter: {
             position: {
-                x: -379.4474792480469,
-                y: 219.0102996826172,
-                z: 83.65795135498047
+                x: -430.1134948730469,
+                y: 259.8076171875,
+                z: 82.99549102783203
             },
             doorPos: {
-                x: -380.0100402832031,
-                y: 217.66558837890625,
-                z: 83.96115112304688
+                x: -430.72467041015625,
+                y: 262.2591857910156,
+                z: 83.4229736328125
             },
-            doorRot: 0,
-            doorModel: 'prop_cntrdoor_ld_l'
+            doorRot: -6,
+            doorModel: "prop_cntrdoor_ld_l"
         },
         exit: {
             position: {
-                x: 127.9552,
-                y: -1298.503,
-                z: 29.41962
+                x: -458.790,
+                y: 284.750,
+                z: 78.521
             }
         },
-        interior: '',
+        interior: 'v_comedy',
         lockstate: 0,
         isGarage: 0,
         salePrice: -1
     },
-    {
-        // Strip Club (DJ Booth)
-        id: 17,
-        guid: -1,
-        enter: {
-		position: {
-			x: -394.3876037597656,
-			y: 209.46859741210938,
-			z: 83.61905670166016
-		},
-		doorPos: {
-			x: -393.7504577636719,
-			y: 209.10105895996094,
-			z: 83.98570251464844
-		},
-		doorRot: -90,
-		doorModel: 'prop_cntrdoor_ld_l'
-        },
-        exit: {
-            position: {
-                x: 126.135,
-                y: -1278.583,
-                z: 29.270
-            }
-        },
-        interior: '',
-        lockstate: 0,
-        isGarage: 0,
-        salePrice: -1
-    }
 ];

--- a/resources/orp/server/entities/entities.mjs
+++ b/resources/orp/server/entities/entities.mjs
@@ -260,6 +260,10 @@ export const Door = new orm.EntitySchema({
         lockstate: {
             type: 'int',
             default: 0
+        },
+        salePrice: {
+            type: 'int',
+            default: 100000
         }
     }
 });

--- a/resources/orp/server/entities/entities.mjs
+++ b/resources/orp/server/entities/entities.mjs
@@ -251,36 +251,15 @@ export const Door = new orm.EntitySchema({
         id: {
             primary: true,
             type: 'int',
-            generated: true
+            generated: false
         },
         guid: {
             type: 'int',
             default: -1
         },
-        enter: {
-            type: 'text'
-        },
-        exit: {
-            type: 'text'
-        },
-        interior: {
-            type: 'text'
-        },
         lockstate: {
             type: 'int',
             default: 0
-        },
-        isGarage: {
-            type: 'int',
-            default: 0
-        },
-        salePrice: {
-            type: 'int',
-            default: 100000
-        },
-        sector: {
-            type: 'int',
-            default: -1
         }
     }
 });

--- a/resources/orp/server/startup.mjs
+++ b/resources/orp/server/startup.mjs
@@ -116,11 +116,12 @@ function cacheInformation() {
             if (res) {
                 alt.emit('door:CacheDoor', res[0].id, res[0]);
             } else {
-                // Create new door with defaults
+                // Create new door with defaults from configuration
                 let door = {
                     id: Doors[i].id,
                     guid: Doors[i].guid,
                     lockstate: Doors[i].lockstate,
+                    salePrice: Doors[i].salePrice
                 }
                 db.insertData(door, 'Door', res => {
                     alt.emit('door:CacheDoor', door.id, door);

--- a/resources/orp/server/startup.mjs
+++ b/resources/orp/server/startup.mjs
@@ -109,30 +109,25 @@ function cacheInformation() {
         }
     });
 
-    // Create doors that are not found in configuration
-    // Only store the dynamic values, the rest come from configuration
+    // Cache dynamic doors
+    // Only persists the dynamic values
     for (let i = 0; i < Doors.length; i++) {
         db.fetchByIds(Doors[i].id, 'Door', res => {
-            if (!res) {
-                db.insertData({
+            if (res) {
+                alt.emit('door:CacheDoor', res[0].id, res[0]);
+            } else {
+                // Create new door with defaults
+                let door = {
                     id: Doors[i].id,
                     guid: Doors[i].guid,
                     lockstate: Doors[i].lockstate,
-                }, 'Door', res => {
-                    alt.log(`Created new door: ${Doors[i].id}`);
+                }
+                db.insertData(door, 'Door', res => {
+                    alt.emit('door:CacheDoor', door.id, door);
                 });
             }
         });
     }
-
-    // Cache doors from DB
-    db.fetchAllData('Door', res => {
-        if (res) {
-            for (let i = 0; i < res.length; i++) {
-                alt.emit('door:CacheDoor', res[i].id, res[i]);
-            }
-        }
-    });
 
     alt.emit('cache:Complete');
 }

--- a/resources/orp/server/systems/door.mjs
+++ b/resources/orp/server/systems/door.mjs
@@ -117,14 +117,15 @@ alt.on('door:LockDynamicDoor', (player, data) => {
     }
 });
 
-// Door cache initially comes from Door configuration
-// and we overwrite with dynamic values from the DB.
+// Door cache values initially comes from Door configuration
+// that is merged in with dynamic values from the DB.
+// data is door data from DB.
 alt.on('door:CacheDoor', (id, data) => {
     let door = Doors.find(x => x.id === id);
 
+    // Overwrite conf values with DB values
     door.guid = data.guid;
     door.lockstate = data.lockstate;
-    alt.log(JSON.stringify(door));
 
     if (!door.sector) {
         let lastDist;
@@ -137,7 +138,7 @@ alt.on('door:CacheDoor', (id, data) => {
                 z: (sector.coords.first.z + sector.coords.second.z) / 2
             };
 
-            const dist = distance(door.enter, pos);
+            const dist = distance(door.enter.position, pos);
             if (!lastDist) {
                 lastDist = dist;
                 currentIndex = index;

--- a/resources/orp/server/systems/door.mjs
+++ b/resources/orp/server/systems/door.mjs
@@ -27,24 +27,21 @@ function changeDoorOwnership(door) {
 alt.on('door:ExitDynamicDoor', (player, id) => {
     const door = getDoor(id);
     if (!door) return;
-    const exitData = JSON.parse(door.exit);
-    const dist = distance(exitData.position, player.pos);
+    const dist = distance(door.exit.position, player.pos);
     if (dist > 5) return;
 
     player.emitMeta('door:EnteredInterior', undefined);
     player.dimension = 0;
     player.saveDimension(0);
 
-    const enterData = JSON.parse(door.enter);
-
     if (player.vehicle) {
-        player.vehicle.pos = enterData.position;
+        player.vehicle.pos = door.enter.position;
         player.vehicle.dimension = 0;
         if (player.vehicle.saveDimension) {
             player.vehicle.saveDimension(0);
         }
     } else {
-        player.pos = enterData.position;
+        player.pos = door.enter.position;
     }
 
     if (player.preColshape) {
@@ -91,8 +88,7 @@ alt.on('door:LockDynamicDoor', (player, data) => {
     const id = data.id;
     const door = getDoor(id);
     if (!door) return;
-    const enterData = JSON.parse(door.enter);
-    const dist = distance(enterData.position, player.pos);
+    const dist = distance(door.enter.position, player.pos);
     if (dist > 5) return;
 
     if (door.guid !== player.data.id) {
@@ -185,6 +181,7 @@ alt.on('door:PurchaseDynamicDoor', (player, data) => {
     // Server Ownership
     if (door.guid <= -1) {
         if (!player.subCash(door.salePrice)) {
+            player.playAudio('error');
             player.notify('You do not have enough cash.');
             return;
         }
@@ -203,6 +200,7 @@ alt.on('door:PurchaseDynamicDoor', (player, data) => {
         }
 
         if (!player.subCash(door.salePrice)) {
+            player.playAudio('error');
             player.notify('You do not have enough cash.');
             return;
         }
@@ -217,5 +215,4 @@ alt.on('door:PurchaseDynamicDoor', (player, data) => {
         changeDoorOwnership(door);
     });
 
-    player.notify('You have purchased this location.');
 });

--- a/resources/orp/server/systems/door.mjs
+++ b/resources/orp/server/systems/door.mjs
@@ -56,8 +56,7 @@ alt.on('door:UseDynamicDoor', (player, data) => {
     const id = data.id;
     const door = getDoor(id);
     if (!door) return;
-    const enterData = JSON.parse(door.enter);
-    const dist = distance(enterData.position, player.pos);
+    const dist = distance(door.enter.position, player.pos);
     if (dist > 5) return;
 
     if (door.lockstate) {
@@ -70,7 +69,6 @@ alt.on('door:UseDynamicDoor', (player, data) => {
         return;
     }
 
-    const exitData = JSON.parse(door.exit);
     player.preColshape = player.colshape;
 
     if (player.vehicle) {
@@ -82,7 +80,7 @@ alt.on('door:UseDynamicDoor', (player, data) => {
         }
     } else {
         player.dimension = door.id;
-        player.pos = exitData.position;
+        player.pos = door.exit.position;
     }
 
     player.saveDimension(door.id);
@@ -126,6 +124,7 @@ alt.on('door:CacheDoor', (id, data) => {
     // Overwrite conf values with DB values
     door.guid = data.guid;
     door.lockstate = data.lockstate;
+    door.salePrice = data.salePrice;
 
     if (!door.sector) {
         let lastDist;
@@ -180,8 +179,7 @@ alt.on('door:PurchaseDynamicDoor', (player, data) => {
     const id = data.id;
     let door = getDoor(id);
     if (!door) return;
-    const enterData = JSON.parse(door.enter);
-    const dist = distance(enterData.position, player.pos);
+    const dist = distance(door.enter.position, player.pos);
     if (dist > 5) return;
 
     // Server Ownership
@@ -218,4 +216,6 @@ alt.on('door:PurchaseDynamicDoor', (player, data) => {
         });
         changeDoorOwnership(door);
     });
+
+    player.notify('You have purchased this location.');
 });


### PR DESCRIPTION
### What are you comitting?

Changing the door cache system to separate dynamic DB values from static file-based values.
The door cache contains values from both in a single hash.

This makes it easier to edit the static door data.   Simply update the static configuration in the door config (based on a fixed ID).   The dynamic values (owner, lockstate, salePrice) remain dynamic in the DB.

The ID is now *fixed* and stored in the configuration file.

Left debug in place to see the result:
```
[15:28:33] Cached door 13: {"id":13,"guid":-1,"enter":{"position":{"x":97.83072662353516,"y":-255.8639373779297,"z":51.4992561340332},"doorPos":{"x":97.01960754394531,"y":-256.3221130371094,"z":51.63471984863281},"doorRot":-21,"doorModel":"prop_cntrdoor_ld_l"},"exit":{"position":{"x":266.0455322265625,"y":-1007.197509765625,"z":-101.00851440429688}},"interior":"","lockstate":0,"isGarage":0,"salePrice":85000,"sector":84}
```

Note: You'll need to drop the Door table in the DB before restarting server since this removes a few columns and changing the id.

### Why are you comitting this?

Am hoping this makes it easier to manage door data.

### What steps did you take to maintain a similar code style as the master branch



### Anything else...
