### PR TITLE
Access ATM panels from all bank interiors

### DIFF
--- a/resources/orp/client/blips/bliphelper.mjs
+++ b/resources/orp/client/blips/bliphelper.mjs
@@ -114,7 +114,7 @@ alt.onServer('grid:TempTurfs', sectors => {
 
 // Load ATM Blips
 Atms.forEach(atm => {
-    createBlip('atm', atm, 108, 53, 'ATM', 5);
+    createBlip('atm', atm, 277, 53, 'ATM', 5);
 });
 
 FuelStations.forEach(station => {

--- a/resources/orp/client/systems/shop.mjs
+++ b/resources/orp/client/systems/shop.mjs
@@ -5,6 +5,7 @@ import * as panelsVehicleCustom from '/client/panels/vehiclecustom.mjs';
 import * as panelsGeneralStore from '/client/panels/generalstore.mjs';
 import * as panelsCrafting from '/client/panels/crafting.mjs';
 import * as panelsCharacter from '/client/panels/character.mjs';
+import * as panelsAtm from '/client/panels/atm.mjs';
 import { createBlip } from '/client/blips/bliphelper.mjs';
 import { syncDoors } from '/client/systems/doors.mjs';
 
@@ -138,6 +139,15 @@ const shops = [
         ],
         func: panelsCrafting.weaponryCrafting,
         message: `Press ~INPUT_CONTEXT~ to access this crafting point.`
+    },
+    {
+        category: 'bank',
+        type: 'Bank',
+        sprite: 108,
+        color: 53,
+        ids: [141057, 165121, 137985, 174849, 179969, 234241, 139265],
+        func: panelsAtm.showDialogue,
+        message: `Press ~INPUT_CONTEXT~ to access funds.`
     }
 ];
 


### PR DESCRIPTION
### What are you comitting?

- Access ATM panels from all bank interiors
- Bank blips use the normal sized dollar symbol
- ATM blips use the smaller dollar symbol (minimap only)

### Why are you comitting this?

Banks should provide operational means for accessing funds for players.

### What steps did you take to maintain a similar code style as the master branch

...

### Anything else...
