### PR TITLE
fixes to dockerfile to support spaces in vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,21 +75,21 @@ RUN cat resources/orp/server/discord/configuration.json
 
 # AltV configuration
 RUN echo '\
-name: "'$SERVER_NAME'"\n\
+name: '$SERVER_NAME'\n\
 host: 0.0.0.0\n\
 port: 7788\n\
-players: "'$SERVER_PLAYERS'"\n\
-announce: "'$SERVER_ANNOUNCE'"\n\
+players: '$SERVER_PLAYERS'\n\
+announce: '$SERVER_ANNOUNCE'\n\
 gamemode: ORP\n\
-website: "'$SERVER_WEBSITE'"\n\
-language: "'$SERVER_LANGUAGE'"\n\
-description: "'$SERVER_DESCRIPTION'"\n\
+website: '$SERVER_WEBSITE'\n\
+language: '$SERVER_LANGUAGE'\n\
+description: '$SERVER_DESCRIPTION'\n\
 modules: [ node-module ]\n\
 resources: [ orp, hospital-pillbox, club-bahama, comedy-club ]\n\
-token: "'$SERVER_TOKEN'"\n\
-debug: "'$SERVER_DEBUG'"\n\
-streamingDistance: "'$SERVER_STREAMINGDISTANCE'"\n\
-password: "'$SERVER_PASSWORD'"\n\
+token: '$SERVER_TOKEN'\n\
+debug: '$SERVER_DEBUG'\n\
+streamingDistance: '$SERVER_STREAMINGDISTANCE'\n\
+password: '$SERVER_PASSWORD'\n\
 ' > server.cfg
 RUN cat server.cfg
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,16 @@ services:
     build: 
       context: .
       args:
-        - SERVER_NAME=Dockerized Open RP
-        - SERVER_DESCRIPTION=Demonstration Purposes Only
+        - SERVER_NAME='Dockerized Open RP'
+        - SERVER_DESCRIPTION='Demonstration Purposes Only'
         - SERVER_PLAYERS=64
         - SERVER_ANNOUNCE=false
-        - SERVER_TOKEN=
-        - SERVER_WEBSITE=twitch.tv/stuykgaming
+        - SERVER_TOKEN=''
+        - SERVER_WEBSITE='twitch.tv/stuykgaming'
         - SERVER_LANGUAGE=en
         - SERVER_DEBUG=true
         - SERVER_STREAMINGDISTANCE=300
-        - SERVER_PASSWORD=
+        - SERVER_PASSWORD=''
         - DISCORD_URL=
         - DISCORD_TOKEN=
         - ALTV_VERSION=beta
@@ -29,6 +29,8 @@ services:
     container_name: db
     environment:
       - POSTGRES_DB=altv
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
     volumes:
       - db_data:/var/lib/postgresql/data
 volumes:


### PR DESCRIPTION
### What are you comitting?

found some issues configuring orp w/ docker where vars with spaces caused issues with altv-server.

### Why are you comitting this?

fixes

### What steps did you take to maintain a similar code style as the master branch



### Anything else...

It turns out that altv server on linux will segfault if you specify `password:` in `server.cfg`.   To overcome this, you must specify an empty string.  Eg. `password: ''`
